### PR TITLE
Chmod first

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN mkdir -p .mf && \
     chown -R worker:nodejs /app && \
     chown -R worker:nodejs /home/worker
 
+# Copy and setup start script with proper permissions
+COPY --chmod=755 start.sh /app/start.sh
+
 # Switch to non-root user for security
 USER worker
 
@@ -50,9 +53,5 @@ EXPOSE 8787
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8787/health || exit 1
 
-# Create a startup script to handle environment variables
-COPY --chown=worker:nodejs start.sh /app/start.sh
-RUN chmod +x /app/start.sh
-
-# Use the startup script as entrypoint
+# Run the startup script
 ENTRYPOINT ["/app/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN mkdir -p .mf && \
     chown -R worker:nodejs /app && \
     chown -R worker:nodejs /home/worker
 
-# Copy and setup start script with proper permissions
-COPY --chmod=755 start.sh /app/start.sh
+# Copy and setup start script with proper permissions and ownership
+COPY --chmod=755 --chown=worker:nodejs start.sh /app/start.sh
 
 # Switch to non-root user for security
 USER worker


### PR DESCRIPTION
Fixes #14 
This pull request updates the Dockerfile to streamline the setup and permissions of the `start.sh` startup script. The changes simplify the process by using Docker's built-in features for file permissions and remove redundant commands.

Improvements to Dockerfile setup and permissions:

* Replaced the manual `chmod` and `chown` commands for `start.sh` with a single `COPY --chmod=755` instruction, ensuring the script has execute permissions immediately upon copying.
* Removed redundant `COPY --chown` and `RUN chmod +x` lines for `start.sh`, relying on the updated `COPY` command for both placement and permissions.

Entrypoint configuration:

* Clarified the use of the startup script by directly setting it as the Docker entrypoint, ensuring consistent container initialization.