### PR TITLE
Protect Ollama /tags route with auth middleware

### DIFF
--- a/src/routes/ollama.ts
+++ b/src/routes/ollama.ts
@@ -149,7 +149,7 @@ ollama.post("/show", openaiAuthMiddleware(), async (c) => {
 	});
 });
 
-ollama.get("/tags", async (c) => {
+ollama.get("/tags", openaiAuthMiddleware(), async (c) => {
 	// For /api/tags, we directly proxy the request to the upstream Ollama server
 	const { response: upstream, error: errorResp } = await startUpstreamRequest(
 		c.env,


### PR DESCRIPTION
### Motivation
- Ensure the Ollama `GET /api/tags` endpoint is protected by the same OpenAI API key authentication as the other Ollama routes to avoid an unintentionally public `/api/*` route.

### Description
- Add `openaiAuthMiddleware()` to the `ollama.get("/tags", ...)` declaration in `src/routes/ollama.ts`, changing it to `ollama.get("/tags", openaiAuthMiddleware(), async (c) => { ... })`.

### Testing
- Ran `rg 'ollama\.(get|post)\(' -n src/routes/ollama.ts && rg 'openai\.(get|post)\(' -n src/routes/openai.ts` and inspected `docs/authentication.md` to verify all exposed `/api` routes now include the auth middleware; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b42f4ae650832d9aa8b8e341fcb720)