### PR TITLE
Refactor start script to allowlist .dev.vars generation

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -34,6 +34,8 @@ cp .dev.vars.example .dev.vars
 
 Edit [`.dev.vars`](./.dev.vars) with your configuration:
 
+> ⚠️ `start.sh` only auto-writes an allowlisted subset of variables into `.dev.vars` when the file does not already exist. Create `.dev.vars` manually when handling sensitive credentials or custom values; auto-generated files are convenience-only and should still be treated as secrets.
+
 ```bash
 # OpenAI API Configuration
 OPENAI_API_KEY=your_api_key_here
@@ -84,6 +86,8 @@ The service will be available at `http://localhost:8787`
 | `OPENAI_API_KEY` | Your OpenAI API key for authentication | ✅ | - |
 | `CHATGPT_RESPONSES_URL` | OpenAI API endpoint URL | ✅ | - |
 | `OPENAI_CODEX_AUTH` | JSON string with access tokens | ✅ | - |
+| `CHATGPT_LOCAL_CLIENT_ID` | Local ChatGPT client identifier | ❌ | - |
+| `OLLAMA_API_URL` | Ollama endpoint URL for local model routing | ❌ | - |
 | `REASONING_EFFORT` | AI reasoning depth: `minimal`, `low`, `medium`, `high` | ❌ | `minimal` |
 | `REASONING_SUMMARY` | Summary mode: `auto`, `on`, `off` | ❌ | `auto` |
 | `REASONING_COMPAT` | Compatibility mode: `think-tags`, `standard` | ❌ | `think-tags` |

--- a/start.sh
+++ b/start.sh
@@ -1,18 +1,43 @@
 #!/bin/bash
 
-# Create .dev.vars file from environment variables
-echo "# Auto-generated .dev.vars file" > .dev.vars
+set -euo pipefail
 
-# Loop through all environment variables
-env | while read -r line; do
-  # Skip variables that are Docker/system specific
-  if [[ ! $line =~ ^(PATH|PWD|HOME|HOSTNAME|NODE_|npm_|YARN_|TERM|SHLVL|_).*$ ]]; then
-    echo "$line" >> .dev.vars
-  fi
-done
+DEV_VARS_FILE=".dev.vars"
 
-# Log that environment variables were processed
-echo "Environment variables have been written to .dev.vars"
+# Respect manually created credentials/config files.
+if [[ -f "$DEV_VARS_FILE" ]]; then
+  echo "$DEV_VARS_FILE already exists; skipping auto-generation."
+else
+  {
+    echo "# Auto-generated .dev.vars file"
+
+    # Explicit allowlist of variables used by this worker.
+    ALLOWED_KEYS=(
+      "OPENAI_API_KEY"
+      "OPENAI_CODEX_AUTH"
+      "CHATGPT_LOCAL_CLIENT_ID"
+      "CHATGPT_RESPONSES_URL"
+      "OLLAMA_API_URL"
+      "DEBUG_MODEL"
+      "VERBOSE"
+    )
+
+    for key in "${ALLOWED_KEYS[@]}"; do
+      if [[ -n "${!key:-}" ]]; then
+        printf '%s=%s\n' "$key" "${!key}"
+      fi
+    done
+
+    # Include optional reasoning controls via prefix allowlist.
+    while IFS= read -r key; do
+      if [[ -n "${!key:-}" ]]; then
+        printf '%s=%s\n' "$key" "${!key}"
+      fi
+    done < <(compgen -e | sort | while IFS= read -r env_key; do [[ "$env_key" == REASONING_* ]] && echo "$env_key"; done)
+  } > "$DEV_VARS_FILE"
+
+  echo "Wrote allowlisted environment variables to $DEV_VARS_FILE"
+fi
 
 # Start wrangler with the local environment variables
 exec wrangler dev --host 0.0.0.0 --port 8787 --local --persist-to .mf


### PR DESCRIPTION
### Motivation

- Prevent leaking unrelated runtime/container environment variables into `.dev.vars` by generating only the app-required keys. 
- Preserve manually managed credential files by skipping auto-generation when `.dev.vars` already exists.

### Description

- Replace the broad `env | while read ...` export logic with an explicit allowlist of keys written to `.dev.vars`: `OPENAI_API_KEY`, `OPENAI_CODEX_AUTH`, `CHATGPT_LOCAL_CLIENT_ID`, `CHATGPT_RESPONSES_URL`, `OLLAMA_API_URL`, `DEBUG_MODEL`, and `VERBOSE`.
- Add prefix-based inclusion for optional `REASONING_*` variables via environment enumeration so reasoning controls are preserved when present.
- Skip generating `.dev.vars` if the file already exists and make the script stricter with `set -euo pipefail`.
- Update `docs/docker.md` to document the allowlist behavior and add `CHATGPT_LOCAL_CLIENT_ID` and `OLLAMA_API_URL` to the environment variable table; `.dev.vars` remains gitignored.

### Testing

- Ran a shell syntax check with `bash -n start.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b42f4f93c0832d9c26d59af261941c)