### PR TITLE
Fix auth middleware handling for missing OpenAI key

### DIFF
--- a/src/middleware/openaiAuthMiddleware.ts
+++ b/src/middleware/openaiAuthMiddleware.ts
@@ -21,7 +21,7 @@ export function openaiAuthMiddleware() {
 		const configuredKey = c.env.OPENAI_API_KEY;
 
 		if (!configuredKey) {
-			await next();
+			return c.json({ error: { message: "Server configuration error" } }, 500);
 		}
 
 		if (providedKey !== configuredKey) {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,24 +1,59 @@
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
-import worker from '../src/index';
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { openaiAuthMiddleware } from "../src/middleware/openaiAuthMiddleware";
+import type { Env } from "../src/types";
 
-// For now, you'll need to do something like this to get a correctly-typed
-// `Request` to pass to `worker.fetch()`.
-const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
+const buildApp = () => {
+	const app = new Hono<{ Bindings: Env }>();
+	app.use("*", openaiAuthMiddleware());
+	app.get("/", (c) => c.json({ ok: true }, 200));
+	return app;
+};
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new IncomingRequest('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+describe("openaiAuthMiddleware", () => {
+	it("returns 401 when Authorization header is missing", async () => {
+		const app = buildApp();
+		const response = await app.request("http://localhost/", {}, { OPENAI_API_KEY: "sk-configured" } as Env);
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({ error: { message: "Missing Authorization header" } });
 	});
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('https://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
+	it("returns 401 for invalid bearer format", async () => {
+		const app = buildApp();
+		const response = await app.request(
+			"http://localhost/",
+			{ headers: { Authorization: "Token sk-configured" } },
+			{ OPENAI_API_KEY: "sk-configured" } as Env
+		);
+
+		expect(response.status).toBe(401);
+		expect(await response.json()).toEqual({
+			error: { message: "Invalid Authorization header format. Expected: Bearer <token>" }
+		});
+	});
+
+	it("returns 500 when OPENAI_API_KEY is missing", async () => {
+		const app = buildApp();
+		const response = await app.request(
+			"http://localhost/",
+			{ headers: { Authorization: "Bearer sk-any" } },
+			{} as Env
+		);
+
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({ error: { message: "Server configuration error" } });
+	});
+
+	it("allows the request to proceed with a valid key", async () => {
+		const app = buildApp();
+		const response = await app.request(
+			"http://localhost/",
+			{ headers: { Authorization: "Bearer sk-valid" } },
+			{ OPENAI_API_KEY: "sk-valid" } as Env
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ ok: true });
 	});
 });


### PR DESCRIPTION
### Motivation

- Ensure the authentication middleware stops processing and surfaces a server-side configuration error when `OPENAI_API_KEY` is not set. 
- Keep the existing error envelope shape `{ error: { message: ... } }` and avoid accidental fall-through to downstream handlers.

### Description

- Updated `openaiAuthMiddleware()` so the `if (!configuredKey)` branch immediately returns `c.json({ error: { message: "Server configuration error" } }, 500)` instead of calling `next()`.
- Ensured there is no fall-through in that branch by returning early.
- Replaced the placeholder worker tests with focused middleware tests in `test/index.spec.ts` that cover missing `Authorization` (`401`), invalid bearer format (`401`), missing `OPENAI_API_KEY` (`500`), and valid key allowing the request (`200`).

### Testing

- Ran `npx vitest run test/index.spec.ts --config vitest.local.config.mts` and all middleware tests passed (4 passed).
- Ran `npm run tsc` which succeeded with no type errors.
- Ran `npm run lint` which completed successfully.
- Note: the default `npm test` path in this environment fails due to a missing `wrangler.jsonc` file, so the focused middleware tests were run with a temporary Vitest config instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b42f49c1dc832db811c064a71e80cb)